### PR TITLE
Remove alerts and replace with changing button text for addContact()

### DIFF
--- a/js/scripts.js
+++ b/js/scripts.js
@@ -265,7 +265,7 @@ function doDelete(contactId) {
 
 function doEdit(firstName, lastName, phone, email, contactId) {
     if (!validatePhoneNumber(phone) || !validateEmail(email)) {
-        window.alert("Invalid format of phone or email!");
+        //window.alert("Invalid format of phone or email!");
         return -1;
     }
     let tmp = { firstName: firstName, lastName: lastName, phone: phone, email: email, contactId: contactId };
@@ -825,13 +825,13 @@ function addContact() {
     let email = document.getElementById("addEmailInput").value;
 
     if (!validatePhoneNumber(phone) && !validateEmail(email)) {
-        window.alert("Invalid formatting of email / phone");
+        //window.alert("Invalid formatting of email / phone");
         return; // TODO: add some sort of error message
     }
 
     // avoid processing blank names
     if (firstName === "" || lastName === "") {
-        window.alert("You cannot have blank first or last names");
+        //window.alert("You cannot have blank first or last names");
         return; // TODO: add some sort of error message
     }
 
@@ -858,4 +858,6 @@ function addContact() {
     document.getElementById("addPhoneInput").value = "";
     document.getElementById("addEmailInput").value = "";
     window.alert("Successfully Added Contact");
+    document.getElementById('addButton').innerText = 'Success!';
+    setTimeout(function() {document.getElementById('addButton').innerText = 'Add Contact';}, 2000);
 }


### PR DESCRIPTION
I removed the alerts from the edit function because it already has error text if the format of the new contact information is invalid. I removed some of the alerts from addContact() and switched the success alert to a temporary change of the text of the button for 2 seconds to a message "Success!"